### PR TITLE
Fix player bar receiving input even when windows overlap it

### DIFF
--- a/src/components/Player.jsx
+++ b/src/components/Player.jsx
@@ -156,7 +156,7 @@ const Player = (props) => {
           max={duration ? duration : `${duration}`}
           className="audio-progress"
           onChange={(e) => onScrub(e.target.value)}
-          onMouseUp={onScrubEnd}
+          onClick={onScrubEnd}
           onKeyUp={onScrubEnd}
         />
       </div>


### PR DESCRIPTION
Was wondering why the music unexpectedly starts when clicking around the area with a maximized window.

| Before | After |
| --- | --- |
| ![DaV5G20xCM](https://github.com/OriginalCube/Bocchi-Wallpaper/assets/35318437/99043e88-7f23-4789-aa95-cc40ca6343c7) | ![O8F4QEpAQq](https://github.com/OriginalCube/Bocchi-Wallpaper/assets/35318437/c19d3ca2-1330-45b1-a361-4ed13088ca39) |