### PR TITLE
Fix progress bar not immediately resetting to 0 when song changes

### DIFF
--- a/src/components/Player.jsx
+++ b/src/components/Player.jsx
@@ -126,6 +126,7 @@ const Player = (props) => {
     if (isReady.current) {
       audioRef.current.play();
       setPlaying(true);
+      setProgress(audioRef.current.currentTime);
       startTimer();
     } else {
       // Set the isReady ref as true for the next pass


### PR DESCRIPTION
| Before | After |
| --- | --- |
| ![LOg46w1c4d](https://github.com/OriginalCube/Bocchi-Wallpaper/assets/35318437/b70633fb-cc43-4d26-a176-f9290fb9a265) | ![px3SG8ihKY](https://github.com/OriginalCube/Bocchi-Wallpaper/assets/35318437/8b1461fc-9f7b-484b-8984-b3776bf83823) |