### PR TITLE
Add +/- indicator to show whether a song is in a playlist

### DIFF
--- a/src/Main.jsx
+++ b/src/Main.jsx
@@ -127,15 +127,15 @@ const Main = () => {
     if (songList[y - 1].includes(x)) {
       //Op check
     } else {
-      let tempArray = songList;
+      let tempArray = [...songList];
       tempArray[y - 1].push(x);
       setSongList(tempArray);
       localStorage.setItem("playlistBocchi", JSON.stringify(tempArray));
     }
   };
 
-  const removeSong = () => {
-    songList[mode - 1].splice(key, 1);
+  const removeSong = (y) => {
+    songList[y - 1].splice(key, 1);
     setSongList([...songList]);
     localStorage.setItem("playlistBocchi", JSON.stringify(songList));
   };

--- a/src/components/Playlist.jsx
+++ b/src/components/Playlist.jsx
@@ -17,7 +17,7 @@ const Playlist = (props) => {
     if (x === true) {
       props.addSong(props.songIndex + 1, y);
     } else {
-      props.removeSong();
+      props.removeSong(y);
     }
     audioPlay(0);
   };
@@ -74,6 +74,8 @@ const Playlist = (props) => {
     props.changeMode(e);
     audioPlay(0);
   };
+
+  const includedInPlaylist = (index) => props.songList[index - 1].includes(props.songIndex + 1);
 
   React.useEffect(() => {
     //console.log(playlistPages);
@@ -231,23 +233,23 @@ const Playlist = (props) => {
           <>
             <button
               className="w-1/2 h-full"
-              onClick={() => onFooter(true, 1)}
+              onClick={() => onFooter(!includedInPlaylist(1), 1)}
               style={{
                 borderRight: `3px solid ${SongData[props.songIndex].lineColor}`,
                 height: "100%",
               }}
             >
-              Playlist 1
+              {includedInPlaylist(1) ? "-" : "+"} Playlist 1
             </button>
-            <button className="w-1/2 h-full" onClick={() => onFooter(true, 2)}>
-              Playlist 2
+            <button className="w-1/2 h-full" onClick={() => onFooter(!includedInPlaylist(2), 2)}>
+              {includedInPlaylist(2) ? "-" : "+"} Playlist 2
             </button>
           </>
         ) : (
           <>
             <button
               className="h-full w-full"
-              onClick={() => onFooter(false, 0)}
+              onClick={() => onFooter(false, props.mode)}
               style={{
                 padding: "0px",
               }}


### PR DESCRIPTION
The plus was on older releases, but I felt like it was needed (to differentiate the top and bottom buttons). Made it more interactable by making it also possible to remove songs while in default mode. There were also comments in Steam that say ppl didn't know how to add, so this makes it more intuitive.

![explorer_ZnYrjljVGD](https://github.com/user-attachments/assets/ace97651-7854-46e7-be20-dfb3c138a135)
