### PR TITLE
Show track progress and duration

### DIFF
--- a/src/components/Player.jsx
+++ b/src/components/Player.jsx
@@ -91,7 +91,7 @@ const Player = (props) => {
 
   const toReadableTime = (seconds) => {
     if (isNaN(seconds)) return;
-    var date = new Date(0);
+    const date = new Date(0);
     date.setSeconds(seconds);
     return date.toISOString().substring(15, 19);
   };

--- a/src/index.css
+++ b/src/index.css
@@ -2,10 +2,6 @@
 @tailwind components;
 @tailwind utilities;
 
-* {
-  overflow: hidden;
-}
-
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
@@ -114,7 +110,7 @@ code {
 .audio-progress {
   position: relative;
   width: 100%;
-  margin-top: 0.5vh;
+  margin: 0 5px 0 5px;
   outline: none;
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -110,7 +110,7 @@ code {
 .audio-progress {
   position: relative;
   width: 100%;
-  margin: 0 5px 0 5px;
+  margin: 0 5px;
   outline: none;
 }
 


### PR DESCRIPTION
![explorer_HEzLtBVeBP](https://github.com/user-attachments/assets/92f824ca-a405-4a0b-a14c-e3b875918eb3)

Was in railgun wallpaper but polished the code enough to PR it upstream.

This reworks the code to use `Audio` events instead of intervals because I've encountered an issue when seconds can skip (i.e. 1:12 -> 1.14) sometimes because `setInterval()` is inaccurate and runs slightly over 1 second.

Removes the overflow on wildcard as it causes clipping when adding the time on the range. Doesn't seem to affect anything (at least on the usual 1920x1080 resolution).

Also fixes this bug:
| Before | After |
| --- | --- |
| ![explorer_k64elKupaq](https://github.com/user-attachments/assets/42a7e5b3-1395-47c9-8925-fc6fd6a13ecc) | ![explorer_pbFPXXryRf](https://github.com/user-attachments/assets/88911d04-41c7-488b-ab65-d6e5f5a3d5ae) |