### PR TITLE
Recommend ESLint extension on VS Code

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "dbaeumer.vscode-eslint"
+    ]
+}


### PR DESCRIPTION
Never had the extension installed until now. This change will make VS Code show a popup at the bottom right.

Shows the warnings that `dev`/`build` outputs in the editor. Mostly wanted for those pesky `useEffect` dependencies.

create-react-app already has a config:
https://github.com/OriginalCube/Bocchi-Wallpaper/blob/2c1f7488c5cc4f2498a7fb9613afb5df7d60b0db/package.json#L22-L27
so we don't need to make one ourselves (if it's plenty).