### PR TITLE
Fix lyrics icon not rendering when case-sensitive names matter

### DIFF
--- a/src/components/Optionbar.jsx
+++ b/src/components/Optionbar.jsx
@@ -65,7 +65,7 @@ const Optionbar = (props) => {
         className="optionIcon opacity-80"
       />
       <img
-        src={`./assets/icons/LyricsIcon.png`}
+        src={`./assets/icons/lyricsIcon.png`}
         onClick={() => onPress("lyrics")}
         style={{ top: "35.5%" }}
         alt=""


### PR DESCRIPTION
For example, GitHub Pages.

https://joehuu.github.io/Bocchi-Wallpaper/assets/icons/LyricsIcon.png - 404s
https://joehuu.github.io/Bocchi-Wallpaper/assets/icons/lyricsIcon.png - loads

P.S.: I have had the [deploy workflow](https://github.com/Joehuu/Bocchi-Wallpaper/blob/main/.github/workflows/deploy.yml) on my fork for the railgun branch for a month now. Lemme know if you're interested in putting it upstream, so I can improve it a bit more and PR (just copied it from somewhere (lol), modified a step to use official actions, and ignored the file after it worked). It has maybe unnecessary stuff like specific version set for pnpm and others that can just be removed, I think. And probably change to on `push` instead of `workflow_dispatch` because I wanted the latter for my use case (another branch) but `push` may be better here.