### PR TITLE
Fix clicking lyrics potentially highlighting previous line for a moment

### DIFF
--- a/src/components/Lyrics.jsx
+++ b/src/components/Lyrics.jsx
@@ -32,7 +32,8 @@ const Lyrics = (props) => {
   }, [props.songIndex, props.lyricsDisplay])
 
   const onLineClicked = (startMillisecond) => {
-    audioRef.current.currentTime = startMillisecond / 1000;
+    // Nudge value to fix floating-point issue
+    audioRef.current.currentTime = (startMillisecond + 1) / 1000;
     recoverAutoScrollImmediately();
     keyPress.src = "./assets/audios/keypress.mp3";
     keyPress.volume = props.uiVolume;


### PR DESCRIPTION
Was a floating-point issue. Noticed in the second line of Into the Light.

| Before | After |
| --- | --- |
| ![PowerToys_q2vk2k9yov](https://github.com/user-attachments/assets/05580563-fb18-4b6f-9d26-d5f02370a4e9) | ![chrome_uAJUH9oZX0](https://github.com/user-attachments/assets/5d52ee36-15af-4802-a124-aa0c81465bef) |
| ![PowerToys_S362nSKOet](https://github.com/user-attachments/assets/00fc2906-c30d-4640-8bdc-1cfbf5403d00) | ![PowerToys_BcrgRqlf2C](https://github.com/user-attachments/assets/ab14b793-fffd-44dc-ad06-2f2b13492a3a) |