### PR TITLE
Add option to view both original and romanized lyrics

### DIFF
--- a/src/LyricsDisplay.jsx
+++ b/src/LyricsDisplay.jsx
@@ -1,6 +1,7 @@
 const LyricsDisplay = {
     Original: "original",
-    Romanized: "romanized"
+    Romanized: "romanized",
+    Both: "both"
 }
 
 export default LyricsDisplay;

--- a/src/LyricsDisplay.jsx
+++ b/src/LyricsDisplay.jsx
@@ -1,0 +1,6 @@
+const LyricsDisplay = {
+    Original: "original",
+    Romanized: "romanized"
+}
+
+export default LyricsDisplay;

--- a/src/Main.jsx
+++ b/src/Main.jsx
@@ -5,7 +5,8 @@ import Player from "./components/Player";
 import AudioVisualizer from "./components/AudioVisualizer";
 import SongData from "./components/SongData.json";
 import Playlist from "./components/Playlist";
-import TextDisplay from "./TextDisplay";
+import TitleDisplay from "./TitleDisplay";
+import LyricsDisplay from "./LyricsDisplay";
 import { toFilename } from "./helpers";
 import Lyrics from "./components/Lyrics";
 
@@ -23,8 +24,8 @@ const Main = () => {
   const [songList, setSongList] = React.useState([[], []]);
   const [uiVolume, setUiVolume] = React.useState(0.5);
   const [textSize, setTextSize] = React.useState(1);
-  const [titleDisplay, setTitleDisplay] = React.useState(TextDisplay.English);
-  const [lyricsDisplay, setLyricsDisplay] = React.useState(TextDisplay.Original);
+  const [titleDisplay, setTitleDisplay] = React.useState(TitleDisplay.English);
+  const [lyricsDisplay, setLyricsDisplay] = React.useState(LyricsDisplay.Original);
   const audioRef = React.useRef(new Audio());
 
   const playerHandler = () => {

--- a/src/TitleDisplay.jsx
+++ b/src/TitleDisplay.jsx
@@ -1,7 +1,7 @@
-const TextDisplay = {
+const TitleDisplay = {
     English: "english",
     Original: "original",
     Romanized: "romanized"
 }
 
-export default TextDisplay;
+export default TitleDisplay;

--- a/src/components/Lyrics.jsx
+++ b/src/components/Lyrics.jsx
@@ -69,9 +69,13 @@ const Lyrics = (props) => {
       }}
       onClick={() => onLineClicked(startMillisecond)}
     >
-      {children.map(child => (
-        <div key={child.id}>{child.content}</div>
-      ))}
+      {
+        (children[0].content !== children[1]?.content)
+          ? children.map(child => (
+            <div key={child.id}>{child.content}</div>
+          ))
+          : children[0].content
+      }
     </div>
 
   return (

--- a/src/components/Lyrics.jsx
+++ b/src/components/Lyrics.jsx
@@ -1,10 +1,11 @@
 import React from "react";
 import SongData from "./SongData.json";
-import { Lrc, useRecoverAutoScrollImmediately } from "react-lrc";
+import { MultipleLrc, useRecoverAutoScrollImmediately } from "react-lrc";
 import { toFilename } from "../helpers";
+import LyricsDisplay from "../LyricsDisplay";
 
 const Lyrics = (props) => {
-  const [lyrics, setLyrics] = React.useState("");
+  const [lyrics, setLyrics] = React.useState(["", ""]);
   const [currentTime, setCurrentTime] = React.useState(0);
   const { signal, recoverAutoScrollImmediately } = useRecoverAutoScrollImmediately();
   const audioRef = React.useRef(props.audioRef.current);
@@ -19,9 +20,23 @@ const Lyrics = (props) => {
 
   React.useEffect(() => {
     const abortController = new AbortController();
-    fetch(`./assets/lyrics/${props.lyricsDisplay}/${toFilename(SongData[props.songIndex].name)}.lrc`, { signal: abortController.signal })
-      .then(res => res.text())
-      .then(data => setLyrics(data.replace(/\r\n/g, '\n').replace(/\r/g, '\n')))
+    const newLyrics = ["", ""];
+    const lrcFetches = [];
+
+    if (props.lyricsDisplay === LyricsDisplay.Both) {
+      lrcFetches.push(fetch(`./assets/lyrics/original/${toFilename(SongData[props.songIndex].name)}.lrc`, { signal: abortController.signal }));
+      lrcFetches.push(fetch(`./assets/lyrics/romanized/${toFilename(SongData[props.songIndex].name)}.lrc`, { signal: abortController.signal }));
+    }
+    else {
+      lrcFetches.push(fetch(`./assets/lyrics/${props.lyricsDisplay}/${toFilename(SongData[props.songIndex].name)}.lrc`, { signal: abortController.signal }));
+    }
+
+    Promise.all(lrcFetches)
+      .then(responses => Promise.all(responses.map(r => r.text())))
+      .then(lrcs => {
+        lrcs.forEach((lrc, i) => newLyrics[i] = lrc.replace(/\r\n/g, '\n').replace(/\r/g, '\n'));
+        setLyrics(newLyrics);
+      })
       .catch(function (err) {
         if (err.name !== "AbortError")
           console.error(` Err: ${err}`);
@@ -40,7 +55,7 @@ const Lyrics = (props) => {
     keyPress.play();
   }
 
-  const lineRenderer = ({ active, line: { content, startMillisecond } }) =>
+  const lineRenderer = ({ active, line: { children, startMillisecond } }) =>
     <div
       style={{
         opacity: ".85",
@@ -54,7 +69,9 @@ const Lyrics = (props) => {
       }}
       onClick={() => onLineClicked(startMillisecond)}
     >
-      {content}
+      {children.map(child => (
+        <div key={child.id}>{child.content}</div>
+      ))}
     </div>
 
   return (
@@ -62,9 +79,9 @@ const Lyrics = (props) => {
       className="lrc-container"
       style={{ border: `4.5px solid ${SongData[props.songIndex].lineColor}` }}
     >
-      <Lrc
+      <MultipleLrc
         className="lrc"
-        lrc={lyrics}
+        lrcs={lyrics}
         lineRenderer={lineRenderer}
         currentMillisecond={currentTime}
         recoverAutoScrollSingal={signal}

--- a/src/components/Player.jsx
+++ b/src/components/Player.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import SongData from "./SongData.json";
-import TextDisplay from "../TextDisplay";
+import TitleDisplay from "../TitleDisplay";
 import { toFilename, useEffectEvent } from "../helpers";
 
 const Player = (props) => {
@@ -173,13 +173,13 @@ const Player = (props) => {
   switch (props.titleDisplay)
   {
     default:
-    case TextDisplay.English:
+    case TitleDisplay.English:
       title = SongData[props.songIndex].name;
       break;
-    case TextDisplay.Original:
+    case TitleDisplay.Original:
       title = SongData[props.songIndex].nameOriginal ?? SongData[props.songIndex].name;
       break;
-    case TextDisplay.Romanized:
+    case TitleDisplay.Romanized:
       title = SongData[props.songIndex].nameRomanized ?? SongData[props.songIndex].name;
       break;
   }

--- a/src/components/PlaylistItem.jsx
+++ b/src/components/PlaylistItem.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import SongData from "./SongData.json";
-import TextDisplay from "../TextDisplay";
+import TitleDisplay from "../TitleDisplay";
 
 const PlaylistItem = (props) => {
   let keypress = new Audio();
@@ -16,13 +16,13 @@ const PlaylistItem = (props) => {
   switch (props.titleDisplay)
   {
     default:
-    case TextDisplay.English:
+    case TitleDisplay.English:
       title = SongData[props.id - 1].name;
       break;
-    case TextDisplay.Original:
+    case TitleDisplay.Original:
       title = SongData[props.id - 1].nameOriginal ?? SongData[props.id - 1].name;
       break;
-    case TextDisplay.Romanized:
+    case TitleDisplay.Romanized:
       title = SongData[props.id - 1].nameRomanized ?? SongData[props.id - 1].name;
       break;
   }


### PR DESCRIPTION
As requested by a commenter. May be a better default.

I split title and lyrics display types because I don't think I'll put in the work for English / other languages, as I don't know Japanese that well. And naming this option "Original/Romanized" or "Original & Romanized" is too long, so I had to name it "Both" (which means there could only be two other options).

![explorer_xEFIN0ANbs](https://github.com/user-attachments/assets/9a356aa5-3707-49a7-882a-5dc3be343ec7)

Option to add:
![image](https://github.com/user-attachments/assets/40ca66c5-5225-4e41-bbc6-c6cf1e3d2ade)
