### PR TITLE
Add ability to override background and accent/line colors

### DIFF
--- a/src/Main.jsx
+++ b/src/Main.jsx
@@ -7,7 +7,7 @@ import SongData from "./components/SongData.json";
 import Playlist from "./components/Playlist";
 import TitleDisplay from "./TitleDisplay";
 import LyricsDisplay from "./LyricsDisplay";
-import { toFilename } from "./helpers";
+import { convertWPEColorToCSS, toFilename } from "./helpers";
 import Lyrics from "./components/Lyrics";
 
 const Main = () => {
@@ -28,7 +28,14 @@ const Main = () => {
   const [lyricsDisplay, setLyricsDisplay] = React.useState(LyricsDisplay.Original);
   const [use24HourClock, set24HourClock] = React.useState(true);
   const [showSeconds, setShowSeconds] = React.useState(true);
+  const [overrideBackgroundColor, setOverrideBackgroundColor] = React.useState(false);
+  const [customBackgroundColor, setCustomBackgroundColor] = React.useState("#000000");
+  const [overrideLineColor, setOverrideLineColor] = React.useState(false);
+  const [customLineColor, setCustomLineColor] = React.useState("#ffffff");
   const audioRef = React.useRef(new Audio());
+
+  const backgroundColor = overrideBackgroundColor ? customBackgroundColor : SongData[songIndex].backgroundColor;
+  const lineColor = overrideLineColor ? customLineColor : SongData[songIndex].lineColor;
 
   const playerHandler = () => {
     //Changes and sets the music player
@@ -254,6 +261,12 @@ const Main = () => {
         if (properties.lyricsdisplay) setLyricsDisplay(properties.lyricsdisplay.value)
         if (properties.use24hourclock) set24HourClock(properties.use24hourclock.value)
         if (properties.showseconds) setShowSeconds(properties.showseconds.value)
+        if (properties.overridebackgroundcolor) setOverrideBackgroundColor(properties.overridebackgroundcolor.value)
+        if (properties.custombackgroundcolor) setCustomBackgroundColor(convertWPEColorToCSS(properties.custombackgroundcolor.value))
+        // Wallpaper Engine properties are named with "accent" instead of "line" as the color is being used in places other than border lines
+        // TODO: rename line color to accent color in another refactor
+        if (properties.overrideaccentcolor) setOverrideLineColor(properties.overrideaccentcolor.value)
+        if (properties.customaccentcolor) setCustomLineColor(convertWPEColorToCSS(properties.customaccentcolor.value, .9))
       },
       setPaused: function (isPaused) {
         setWPEPaused(isPaused);
@@ -266,10 +279,10 @@ const Main = () => {
   return (
     <div
       className="Main"
-      style={{ backgroundColor: SongData[songIndex].backgroundColor }}
+      style={{ backgroundColor: backgroundColor }}
     >
       {audioVis === "true" ? (
-        <AudioVisualizer lineColor={SongData[songIndex].lineColor} />
+        <AudioVisualizer lineColor={lineColor} />
       ) : null}
       <img
         className="mainImage"
@@ -301,6 +314,8 @@ const Main = () => {
           addSong={addSong}
           removeSong={removeSong}
           titleDisplay={titleDisplay}
+          backgroundColor={backgroundColor}
+          lineColor={lineColor}
         />
       ) : null}
       {clock === "true" ? (
@@ -333,6 +348,8 @@ const Main = () => {
             audioRef={audioRef}
             uiVolume={uiVolume}
             lyricsDisplay={lyricsDisplay}
+            backgroundColor={backgroundColor}
+            lineColor={lineColor}
           />
         )
       }

--- a/src/components/Lyrics.jsx
+++ b/src/components/Lyrics.jsx
@@ -60,10 +60,10 @@ const Lyrics = (props) => {
       style={{
         opacity: ".85",
         backgroundColor: active
-          ? SongData[props.songIndex].lineColor
+          ? props.lineColor
           : `transparent`,
         padding: `10px`,
-        color: active ? SongData[props.songIndex].backgroundColor : `white`,
+        color: active ? props.backgroundColor : `white`,
         fontWeight: active ? "500" : "normal",
         borderRadius: active ? "5px" : "0px",
       }}
@@ -81,7 +81,7 @@ const Lyrics = (props) => {
   return (
     <div
       className="lrc-container"
-      style={{ border: `4.5px solid ${SongData[props.songIndex].lineColor}` }}
+      style={{ border: `4.5px solid ${props.lineColor}` }}
     >
       <MultipleLrc
         className="lrc"

--- a/src/components/Playlist.jsx
+++ b/src/components/Playlist.jsx
@@ -102,7 +102,7 @@ const Playlist = (props) => {
       className="playlist"
       style={{
         fontSize: `${titleSize * props.textSize}rem`,
-        border: `4.5px solid ${SongData[props.songIndex].lineColor}`,
+        border: `4.5px solid ${props.lineColor}`,
         boxShadow: "1px 1px 6px #150625",
       }}
     >
@@ -111,8 +111,8 @@ const Playlist = (props) => {
           className="h-full w-1/3"
           onClick={() => onChangeMode(0)}
           style={{
-            borderBottom: `3px solid ${SongData[props.songIndex].lineColor}`,
-            borderRight: `3px solid ${SongData[props.songIndex].lineColor}`,
+            borderBottom: `3px solid ${props.lineColor}`,
+            borderRight: `3px solid ${props.lineColor}`,
           }}
         >
           Default
@@ -121,8 +121,8 @@ const Playlist = (props) => {
           className="h-full w-1/3"
           onClick={() => onChangeMode(1)}
           style={{
-            borderBottom: `3px solid ${SongData[props.songIndex].lineColor}`,
-            borderRight: `3px solid ${SongData[props.songIndex].lineColor}`,
+            borderBottom: `3px solid ${props.lineColor}`,
+            borderRight: `3px solid ${props.lineColor}`,
           }}
         >
           Playlist 1
@@ -131,7 +131,7 @@ const Playlist = (props) => {
           className="w-1/3 h-full"
           onClick={() => onChangeMode(2)}
           style={{
-            borderBottom: `3px solid ${SongData[props.songIndex].lineColor}`,
+            borderBottom: `3px solid ${props.lineColor}`,
           }}
         >
           Playlist 2
@@ -151,6 +151,8 @@ const Playlist = (props) => {
                     changeId={props.changeId}
                     mode={props.mode}
                     titleDisplay={props.titleDisplay}
+                    backgroundColor={props.backgroundColor}
+                    lineColor={props.lineColor}
                   />
                 ),
               )
@@ -199,7 +201,7 @@ const Playlist = (props) => {
         <div
           className="playlist-sroll"
           style={{
-            border: `2px solid ${SongData[props.songIndex].lineColor}`,
+            border: `2px solid ${props.lineColor}`,
           }}
         >
           <div
@@ -222,7 +224,7 @@ const Playlist = (props) => {
         className="playlistNavigation"
         style={{
           height: "10%",
-          borderTop: `4.5px solid ${SongData[props.songIndex].lineColor}`,
+          borderTop: `4.5px solid ${props.lineColor}`,
           position: "relative",
         }}
       >
@@ -232,7 +234,7 @@ const Playlist = (props) => {
               className="w-1/2 h-full"
               onClick={() => onFooter(!includedInPlaylist(1), 1)}
               style={{
-                borderRight: `3px solid ${SongData[props.songIndex].lineColor}`,
+                borderRight: `3px solid ${props.lineColor}`,
                 height: "100%",
               }}
             >

--- a/src/components/PlaylistItem.jsx
+++ b/src/components/PlaylistItem.jsx
@@ -34,15 +34,15 @@ const PlaylistItem = (props) => {
         onClick={clickHandle}
         style={{
           opacity: ".85",
-          borderBottom: `3px solid ${SongData[props.songIndex].lineColor}`,
+          borderBottom: `3px solid ${props.lineColor}`,
           backgroundColor:
             props.songIndex === props.id - 1
-              ? SongData[props.songIndex].lineColor
+              ? props.lineColor
               : `transparent`,
           padding: `5px`,
           color:
             props.songIndex === props.id - 1
-              ? SongData[props.songIndex].backgroundColor
+              ? props.backgroundColor
               : "white",
           fontWeight: props.songIndex === props.id - 1 ? "500" : "normal",
           borderRadius: props.songIndex === props.id - 1 ? "5px" : "0px",

--- a/src/helpers.jsx
+++ b/src/helpers.jsx
@@ -2,6 +2,15 @@ import React from "react"
 
 export const toFilename = (str) => str.replace(/[\\/:*?"<>|]/g, '_')
 
+// Taken from https://docs.wallpaperengine.io/en/web/customization/properties.html#color-property with alpha added
+export const convertWPEColorToCSS = (str, alpha = 1) => {
+  var color = str.split(' ');
+  color = color.map(function(c) {
+      return Math.ceil(c * 255);
+  });
+  return 'rgba(' + color + ',' + alpha + ')';
+}
+
 // TODO: replace with native function when added to stable version of React
 // Taken from https://stackoverflow.com/questions/76335194/is-this-an-accurate-polyfill-of-reacts-useeffectevent
 export const useEffectEvent = (callback) => {


### PR DESCRIPTION
Inspired by girls band cry wallpaper having it, but theirs was a bit buggy. My implementation dynamically updates when changing color. Also adds accent/line color override. My use case is just making the background black.
![explorer_YjDNzXMrW3](https://github.com/user-attachments/assets/d36bffb5-040a-4d14-bb7a-880385318a05)

Properties to add:
<img width="568" height="226" alt="image" src="https://github.com/user-attachments/assets/f3ba2a5e-ab47-4ad8-991b-d51eb9f5e113" />
<img width="564" height="231" alt="image" src="https://github.com/user-attachments/assets/0ceebcce-c018-4842-a45b-e453c8680e24" />
<img width="563" height="234" alt="image" src="https://github.com/user-attachments/assets/f627307d-8cc8-4dd5-8bfb-1eae4c7cc5be" />
<img width="571" height="217" alt="image" src="https://github.com/user-attachments/assets/e09d623c-e0b2-4750-b422-e924a03daafe" />
