### PR TITLE
Add initial Wallpaper Engine property translations

### DIFF
--- a/public/project.json
+++ b/public/project.json
@@ -22,6 +22,21 @@
 				"ui_title_display" : "Title display",
 				"ui_volume" : "UI volume"
 			},
+			"es-es" : 
+			{
+				"ui_24_hour_clock" : "Reloj de 24 horas",
+				"ui_both" : "Ambos",
+				"ui_english" : "Inglés",
+				"ui_lyrics_display" : "Mostrar letra",
+				"ui_original" : "Original",
+				"ui_override_accent_color" : "Cambiar color de acento",
+				"ui_override_background_color" : "Cambiar color de fondo",
+				"ui_romanized" : "Romanizado",
+				"ui_show_seconds" : "Mostrar segundos",
+				"ui_text_size" : "Tamaño del texto",
+				"ui_title_display" : "Mostrar título",
+				"ui_volume" : "Volumen de interfaz"
+			},
 			"zh-chs" : 
 			{
 				"ui_24_hour_clock" : "24小时制时钟",


### PR DESCRIPTION
- [x] Depends on https://github.com/OriginalCube/Bocchi-Wallpaper/pull/37

Thanks to アンノウイモ on Steam!

Note that the order of the json is different from what I've posted in the [workshop discussion](https://steamcommunity.com/workshop/filedetails/discussion/2905017768/760680996704115185/) as when you modify/add a property (for whatever reason) in the Wallpaper Engine UI, it remakes the json and alphabetizes the keys, so I just let it do that.

Will edit the post later to alphabetize and add the new "override" property strings.

![ui32_RciyS3Ehhc](https://github.com/user-attachments/assets/7268e49d-2db6-4efc-ab2b-2b27572b6a81)
