### PR TITLE
Fix track progress and duration being truncated when over 10 minutes

### DIFF
--- a/src/__tests__/helpers.test.js
+++ b/src/__tests__/helpers.test.js
@@ -1,0 +1,12 @@
+import { toReadableTime } from "../helpers";
+
+test('toReadableTime', () => {
+    expect(toReadableTime(59)).toEqual('0:59');
+    expect(toReadableTime(60)).toEqual('1:00');
+    expect(toReadableTime(599)).toEqual('9:59');
+    expect(toReadableTime(600)).toEqual('10:00');
+    expect(toReadableTime(3599)).toEqual('59:59');
+    expect(toReadableTime(3600)).toEqual('1:00:00');
+    expect(toReadableTime(86399)).toEqual('23:59:59');
+    expect(toReadableTime(86400)).toEqual('24:00:00');
+});

--- a/src/components/Player.jsx
+++ b/src/components/Player.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import SongData from "./SongData.json";
 import TitleDisplay from "../TitleDisplay";
-import { toFilename, useEffectEvent } from "../helpers";
+import { toFilename, useEffectEvent, toReadableTime } from "../helpers";
 
 const Player = (props) => {
   let keypress = new Audio();
@@ -93,13 +93,6 @@ const Player = (props) => {
   const shuffle = () => {
     props.reShuffle("shuffle", props.shuffle === true ? false : true);
     clickAudio();
-  };
-
-  const toReadableTime = (seconds) => {
-    if (isNaN(seconds)) return;
-    const date = new Date(0);
-    date.setSeconds(seconds);
-    return date.toISOString().substring(15, 19);
   };
 
   React.useEffect(() => {

--- a/src/components/Player.jsx
+++ b/src/components/Player.jsx
@@ -202,7 +202,7 @@ const Player = (props) => {
           className="w-full flex items-center justify-center"
           style={{ marginTop: "10px" }}
         >
-          {toReadableTime(trackProgress)}
+          <div className="text-right flex-1">{toReadableTime(trackProgress)}</div>
           <input
             type="range"
             step="1"
@@ -214,12 +214,9 @@ const Player = (props) => {
             onClick={onScrubEnd}
             onKeyUp={onScrubEnd}
           />
-          {toReadableTime(duration)}
+          <div className="text-left flex-1">{toReadableTime(duration)}</div>
         </div>
-        <div
-          className="flex items-center justify-evenly"
-          style={{ marginTop: "10px" }}
-        >
+        <div className="audioControls flex items-center justify-between">
           <img
             className="audioIcon"
             onClick={() => onReplay()}

--- a/src/helpers.jsx
+++ b/src/helpers.jsx
@@ -31,3 +31,19 @@ export const randomExcluded = (min, max, excluded) => {
     if (n >= excluded) n++;
     return n;
 }
+
+export const toReadableTime = (seconds) => {
+  if (isNaN(seconds)) return;
+  const totalMinutes = seconds / 60;
+  const totalHours = totalMinutes / 60;
+  const hoursPart = Math.floor(totalHours).toString();
+  const minutesPart = Math.floor(totalMinutes % 60).toString();
+  const secondsPart = Math.floor(seconds % 60).toString().padStart(2, "0");
+  let time = "";
+  if (totalHours >= 1)
+    time += `${hoursPart}:${minutesPart.padStart(2, "0")}:`;
+  else
+    time += `${minutesPart}:`;
+  time += secondsPart;
+  return time;
+};

--- a/src/index.css
+++ b/src/index.css
@@ -100,18 +100,26 @@ code {
   position: absolute;
   color: white;
   overflow: visible;
-  width: 25%;
-  height: 10%;
-  left: 37.5%;
   top: 82%;
   text-align: center;
+  margin-left: auto;
+  margin-right: auto;
+  left: 0;
+  right: 0;
 }
 
 .audio-progress {
   position: relative;
-  width: 100%;
+  width: 450px;
   margin: 0 5px;
   outline: none;
+}
+
+.audioControls {
+  margin-top: 10px;
+  width: 450px;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .audioIcon {

--- a/src/index.css
+++ b/src/index.css
@@ -232,7 +232,7 @@ code {
 }
 
 .volume-bar {
-  width: 50%;
+  width: 225px;
   overflow: hidden;
   height: 10px;
   border-radius: 5px;


### PR DESCRIPTION
- Fixes https://github.com/OriginalCube/Bocchi-Wallpaper/issues/53

Tried to match 1920x1080 layout when reworking with fixed width.

Moves `toReadableTime()` so that I can test it and reuse it later (e.g. total playlist length).

| Before | After |
| --- | --- |
|<img width="1920" height="1080" alt="chrome_vtM0xvYiQJ" src="https://github.com/user-attachments/assets/17c3be12-d921-45ee-8977-b96f4cc8786d" /> | <img width="1920" height="1080" alt="chrome_Nso5DdOo9q" src="https://github.com/user-attachments/assets/526f47f0-4abb-4842-9682-430b9faa93e4" /> |